### PR TITLE
swapping slf4j .atDebug() to maven friendly .debug()

### DIFF
--- a/common/src/main/java/dev/ikm/tinkar/common/util/broadcast/SimpleBroadcaster.java
+++ b/common/src/main/java/dev/ikm/tinkar/common/util/broadcast/SimpleBroadcaster.java
@@ -48,7 +48,7 @@ public class SimpleBroadcaster<T> implements Broadcaster<T>, Subscriber<T>{
     }
 
     public void addSubscriberWithWeakReference(Subscriber<T> subscriber) {
-        LOG.atDebug().log(subscriber + " subscribing to " + this);
+        LOG.debug(subscriber + " subscribing to " + this);
         for (WeakReference<Subscriber<T>> subscriberWeakReference: subscriberWeakReferenceList) {
             if (subscriberWeakReference.get() == subscriber) {
                 throw new IllegalStateException("Trying to add duplicate listener: " + subscriber);
@@ -57,7 +57,7 @@ public class SimpleBroadcaster<T> implements Broadcaster<T>, Subscriber<T>{
         subscriberWeakReferenceList.add(new WeakReference<>(subscriber));
     }
     public void removeSubscriber(Subscriber<T> subscriber) {
-        LOG.atDebug().log("Removing " + subscriber + " from " + this);
+        LOG.debug("Removing " + subscriber + " from " + this);
         for (WeakReference<Subscriber<T>> subscriberWeakReference: subscriberWeakReferenceList) {
             if (subscriberWeakReference.get() == subscriber) {
                 subscriberWeakReferenceList.remove(subscriberWeakReference);


### PR DESCRIPTION
Need to change the slf4j method calls for debug logging. There's a weird bug where Maven Mojo's use their own wrapper for debug logging and it doesn't support the SLF4j atDebug().