### PR TITLE
IKDT-970 TypeAheadSearch: moved buildSuggester task into single-threaded executor, await completion on close

### DIFF
--- a/provider/search-provider/src/main/java/dev/ikm/tinkar/provider/search/TypeAheadSearch.java
+++ b/provider/search-provider/src/main/java/dev/ikm/tinkar/provider/search/TypeAheadSearch.java
@@ -44,7 +44,7 @@ public class TypeAheadSearch {
     private static final Logger LOG = LoggerFactory.getLogger(TypeAheadSearch.class);
     private static final String TEXT_FIELD_NAME = "text";
 
-    private final ExecutorService suggesterExecutor = Executors.newSingleThreadExecutor();
+    private static ExecutorService suggesterExecutor;
 
     private AnalyzingSuggester suggester;
     private FuzzySuggester fuzzySuggester;
@@ -54,6 +54,9 @@ public class TypeAheadSearch {
     public static synchronized TypeAheadSearch get() {
         if (typeAheadSearch == null) {
             typeAheadSearch = new TypeAheadSearch();
+        }
+        if (suggesterExecutor == null || suggesterExecutor.isShutdown()) {
+            suggesterExecutor = Executors.newSingleThreadExecutor();
         }
         return typeAheadSearch;
     }


### PR DESCRIPTION
- Moved buildSuggester task into single-threaded executor, await completion on `close` when PrimitiveData.stop() is invoked
- Removed call to buildSuggester from class singleton getter (side-effect)

