### PR TITLE
gRPC datastore and search provider for Komet

### DIFF
--- a/common/pom.xml
+++ b/common/pom.xml
@@ -13,8 +13,14 @@
 <!--    </properties>-->
     <dependencies>
         <dependency>
-            <groupId>com.github.RoaringBitmap.RoaringBitmap</groupId>
-            <artifactId>roaringbitmap</artifactId>
+            <groupId>org.roaringbitmap</groupId>
+            <artifactId>RoaringBitmap</artifactId>
+            <version>1.6.9</version>
+        </dependency>
+        <dependency>
+            <groupId>org.roaringbitmap</groupId>
+            <artifactId>bsi</artifactId>
+            <version>1.6.9</version>
         </dependency>
         <dependency>
             <groupId>dev.ikm.jpms</groupId>

--- a/common/pom.xml
+++ b/common/pom.xml
@@ -13,14 +13,8 @@
 <!--    </properties>-->
     <dependencies>
         <dependency>
-            <groupId>org.roaringbitmap</groupId>
-            <artifactId>RoaringBitmap</artifactId>
-            <version>1.6.9</version>
-        </dependency>
-        <dependency>
-            <groupId>org.roaringbitmap</groupId>
-            <artifactId>bsi</artifactId>
-            <version>1.6.9</version>
+            <groupId>com.github.RoaringBitmap.RoaringBitmap</groupId>
+            <artifactId>roaringbitmap</artifactId>
         </dependency>
         <dependency>
             <groupId>dev.ikm.jpms</groupId>

--- a/common/src/main/java/dev/ikm/tinkar/common/service/NoLocalUserStore.java
+++ b/common/src/main/java/dev/ikm/tinkar/common/service/NoLocalUserStore.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright © 2015 Integrated Knowledge Management (support@ikm.dev)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package dev.ikm.tinkar.common.service;
+
+/**
+ * Marker for a {@link PrimitiveDataService} that has no local author/STAMP store to select a
+ * user from — e.g. a read-only remote-backed provider.
+ *
+ * <p>UI layers check {@code PrimitiveData.get() instanceof NoLocalUserStore} to decide whether
+ * to skip author login/selection after a data source finishes loading, instead of hardcoding a
+ * check against a specific provider implementation.
+ */
+public interface NoLocalUserStore {
+}

--- a/common/src/main/java/dev/ikm/tinkar/common/service/RemoteConceptSearchService.java
+++ b/common/src/main/java/dev/ikm/tinkar/common/service/RemoteConceptSearchService.java
@@ -1,0 +1,111 @@
+/*
+ * Copyright © 2015 Integrated Knowledge Management (support@ikm.dev)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package dev.ikm.tinkar.common.service;
+
+import java.util.List;
+import java.util.UUID;
+
+/**
+ * Search contract for backends that can return rich, grouped/semantic results and
+ * hydrate a full concept graph on demand, in addition to the flat {@link SearchService}
+ * contract.
+ *
+ * <p>Discovered like any other lifecycle-managed service:
+ * <pre>{@code
+ * Optional<RemoteConceptSearchService> remote = ServiceLifecycleManager.get()
+ *     .getRunningService(RemoteConceptSearchService.class);
+ * if (remote.isPresent()) {
+ *     // use remote.get().searchGrouped(...) / .searchFlat(...)
+ * } else {
+ *     // fall back to local search
+ * }
+ * }</pre>
+ * Presence of the service in the returned {@code Optional} is itself the activity signal —
+ * there is no separate {@code isActive()} check.
+ */
+public interface RemoteConceptSearchService {
+
+    /**
+     * Sort options mirroring common UI sort controls.
+     */
+    enum SortOption {
+        TOP_COMPONENT,
+        TOP_COMPONENT_ALPHA,
+        SEMANTIC,
+        SEMANTIC_ALPHA
+    }
+
+    /**
+     * A single semantic match within a {@link GroupedResult}.
+     *
+     * @param highlightedText matched text with {@code <B>…</B>} markup
+     * @param plainText       plain text without HTML markup
+     * @param score           relevance score
+     */
+    record MatchingSemantic(String highlightedText, String plainText, float score) {}
+
+    /**
+     * A top-level (grouped) search result — one per matching concept.
+     *
+     * @param publicId           stable UUIDs identifying the concept
+     * @param fullyQualifiedName FQN of the concept
+     * @param active             whether the concept is currently active
+     * @param topScore           highest relevance score among child semantics
+     * @param matchingSemantics  child semantic matches
+     */
+    record GroupedResult(
+            List<String> publicId,
+            String fullyQualifiedName,
+            boolean active,
+            float topScore,
+            List<MatchingSemantic> matchingSemantics) {}
+
+    /**
+     * A flat semantic search result (SEMANTIC sort modes) — one per matched semantic.
+     *
+     * @param publicId           stable UUIDs identifying the concept
+     * @param fullyQualifiedName FQN of the concept
+     * @param highlightedText    matched text with {@code <B>…</B>} markup
+     * @param active             whether the concept is currently active
+     * @param score              relevance score
+     */
+    record SemanticResult(
+            List<String> publicId,
+            String fullyQualifiedName,
+            String highlightedText,
+            boolean active,
+            float score) {}
+
+    /**
+     * Performs a search returning grouped results (TOP_COMPONENT modes).
+     */
+    List<GroupedResult> searchGrouped(String query, int maxResults, SortOption sortOption);
+
+    /**
+     * Performs a search returning flat semantic results (SEMANTIC modes).
+     */
+    List<SemanticResult> searchFlat(String query, int maxResults, SortOption sortOption);
+
+    /**
+     * Fetches the full entity graph for a concept from the remote backend and loads it
+     * into the local entity store, so subsequent local lookups (name, parents, axioms)
+     * resolve without another round trip.
+     *
+     * @param publicIds the concept's public UUIDs (from a search result)
+     * @return the local NID assigned to the concept after loading
+     */
+    int loadConceptWithSemantics(List<UUID> publicIds);
+}

--- a/provider/data-spinedarray-provider/src/main/resources/META-INF/services/dev.ikm.tinkar.common.service.DataServiceController
+++ b/provider/data-spinedarray-provider/src/main/resources/META-INF/services/dev.ikm.tinkar.common.service.DataServiceController
@@ -1,0 +1,2 @@
+dev.ikm.tinkar.provider.spinedarray.SpinedArrayProvider$OpenController
+dev.ikm.tinkar.provider.spinedarray.SpinedArrayProvider$NewController

--- a/provider/data-spinedarray-provider/src/main/resources/META-INF/services/dev.ikm.tinkar.common.service.ServiceLifecycle
+++ b/provider/data-spinedarray-provider/src/main/resources/META-INF/services/dev.ikm.tinkar.common.service.ServiceLifecycle
@@ -1,0 +1,2 @@
+dev.ikm.tinkar.provider.spinedarray.SpinedArrayProvider$OpenController
+dev.ikm.tinkar.provider.spinedarray.SpinedArrayProvider$NewController

--- a/provider/entity-provider/src/main/java/dev/ikm/tinkar/provider/entity/EntityProvider.java
+++ b/provider/entity-provider/src/main/java/dev/ikm/tinkar/provider/entity/EntityProvider.java
@@ -125,26 +125,40 @@ public class EntityProvider implements EntityService, PublicIdService, DefaultDe
                         }
                         anyString = (String) version.fieldValues().get(indexForText);
                     } else {
-                        Entity<?> entity = patternHandle.expectEntity();
-                        anyString = " <" + entity.nid() + ">" + entity.asUuidList().toString();
-                        // Added in case entity.toString() itself throws an exception, at least get a UUID for the problem.
-                        AlertStreams.getRoot().dispatch(AlertObject.makeError(new IllegalStateException("Expecting a pattern entity. Found entity with id:  " + anyString)));
-                        AlertStreams.getRoot().dispatch(AlertObject.makeError(new IllegalStateException("Expecting a pattern entity. Found: " + entity)));
+                        // Pattern entity is not a PatternEntity. If it is absent (e.g. in gRPC/ephemeral-store mode
+                        // before all entities are loaded) skip silently. Otherwise report the type mismatch.
+                        if (patternHandle.isAbsent()) {
+                            LOG.warn("Pattern entity absent for NID {} while resolving text for NID {} — skipping (gRPC mode)",
+                                    descriptionSemantic.patternNid(), nid);
+                        } else {
+                            Entity<?> entity = patternHandle.expectEntity();
+                            anyString = " <" + entity.nid() + ">" + entity.asUuidList().toString();
+                            // Added in case entity.toString() itself throws an exception, at least get a UUID for the problem.
+                            AlertStreams.getRoot().dispatch(AlertObject.makeError(new IllegalStateException("Expecting a pattern entity. Found entity with id:  " + anyString)));
+                            AlertStreams.getRoot().dispatch(AlertObject.makeError(new IllegalStateException("Expecting a pattern entity. Found: " + entity)));
+                        }
                     }
                 } else {
-                    Entity<?> entity = descriptionSemanticHandle.expectEntity();
-                    anyString = " <" + entity.nid() + "> " + entity.asUuidList().toString();
-                    LOG.error("ERROR getting string for nid: " + anyString);
-                    LOG.error("ERROR Nid - 2: <" + (nid - 2) + "> " + getChronology(nid - 2));
-                    LOG.error("ERROR Nid - 1: <" + (nid - 1) + "> " + getChronology(nid - 1));
-                    LOG.error("ERROR Nid: <" + nid + "> " + getChronology(nid - 1));
-                    LOG.error("ERROR Nid + 1: <" + (nid + 1) + "> " + getChronology(nid + 1));
-                    LOG.error("ERROR Nid + 2: <" + (nid + 2) + "> " + getChronology(nid + 2));
+                    // Description semantic handle is not a SemanticEntity. If absent (gRPC/ephemeral-store mode
+                    // before all entities are loaded) skip silently. Otherwise report the type mismatch.
+                    if (descriptionSemanticHandle.isAbsent()) {
+                        LOG.warn("Description semantic entity absent for NID {} while resolving text for NID {} — skipping (gRPC mode)",
+                                semanticNid, nid);
+                    } else {
+                        Entity<?> entity = descriptionSemanticHandle.expectEntity();
+                        anyString = " <" + entity.nid() + "> " + entity.asUuidList().toString();
+                        LOG.error("ERROR getting string for nid: " + anyString);
+                        LOG.error("ERROR Nid - 2: <" + (nid - 2) + "> " + getChronology(nid - 2));
+                        LOG.error("ERROR Nid - 1: <" + (nid - 1) + "> " + getChronology(nid - 1));
+                        LOG.error("ERROR Nid: <" + nid + "> " + getChronology(nid - 1));
+                        LOG.error("ERROR Nid + 1: <" + (nid + 1) + "> " + getChronology(nid + 1));
+                        LOG.error("ERROR Nid + 2: <" + (nid + 2) + "> " + getChronology(nid + 2));
 
-                    // Added in case entity.toString() itself throws an exception, at least get a UUID for the problem.
-                    AlertStreams.getRoot().dispatch(AlertObject.makeError(new IllegalStateException("Expecting a description semantic entity from list: " +
-                            Arrays.toString(semanticNids) + "\n Found entity with id:  " + anyString)));
-                    AlertStreams.getRoot().dispatch(AlertObject.makeError(new IllegalStateException("Expecting a description semantic. Found: " + entity)));
+                        // Added in case entity.toString() itself throws an exception, at least get a UUID for the problem.
+                        AlertStreams.getRoot().dispatch(AlertObject.makeError(new IllegalStateException("Expecting a description semantic entity from list: " +
+                                Arrays.toString(semanticNids) + "\n Found entity with id:  " + anyString)));
+                        AlertStreams.getRoot().dispatch(AlertObject.makeError(new IllegalStateException("Expecting a description semantic. Found: " + entity)));
+                    }
                 }
             }
             if (fqnString != null) {

--- a/provider/entity-provider/src/main/resources/META-INF/services/dev.ikm.tinkar.common.service.CachingService
+++ b/provider/entity-provider/src/main/resources/META-INF/services/dev.ikm.tinkar.common.service.CachingService
@@ -1,0 +1,1 @@
+dev.ikm.tinkar.provider.entity.EntityProvider$CacheProvider

--- a/provider/entity-provider/src/main/resources/META-INF/services/dev.ikm.tinkar.common.service.ServiceLifecycle
+++ b/provider/entity-provider/src/main/resources/META-INF/services/dev.ikm.tinkar.common.service.ServiceLifecycle
@@ -1,0 +1,2 @@
+dev.ikm.tinkar.provider.entity.EntityProvider$Controller
+dev.ikm.tinkar.provider.entity.StampProvider$Controller

--- a/provider/entity-provider/src/main/resources/META-INF/services/dev.ikm.tinkar.coordinate.PathService
+++ b/provider/entity-provider/src/main/resources/META-INF/services/dev.ikm.tinkar.coordinate.PathService
@@ -1,0 +1,1 @@
+dev.ikm.tinkar.coordinate.stamp.calculator.PathProvider

--- a/provider/entity-provider/src/main/resources/META-INF/services/dev.ikm.tinkar.entity.StampService
+++ b/provider/entity-provider/src/main/resources/META-INF/services/dev.ikm.tinkar.entity.StampService
@@ -1,0 +1,1 @@
+dev.ikm.tinkar.provider.entity.StampProvider

--- a/provider/executor-provider/src/main/resources/META-INF/services/dev.ikm.tinkar.common.alert.AlertReportingService
+++ b/provider/executor-provider/src/main/resources/META-INF/services/dev.ikm.tinkar.common.alert.AlertReportingService
@@ -1,0 +1,1 @@
+dev.ikm.tinkar.provider.executor.AlertLogSubscriber

--- a/provider/executor-provider/src/main/resources/META-INF/services/dev.ikm.tinkar.common.service.ExecutorController
+++ b/provider/executor-provider/src/main/resources/META-INF/services/dev.ikm.tinkar.common.service.ExecutorController
@@ -1,0 +1,1 @@
+dev.ikm.tinkar.provider.executor.ExecutorProvider$Controller

--- a/provider/executor-provider/src/main/resources/META-INF/services/dev.ikm.tinkar.common.service.ServiceLifecycle
+++ b/provider/executor-provider/src/main/resources/META-INF/services/dev.ikm.tinkar.common.service.ServiceLifecycle
@@ -1,0 +1,1 @@
+dev.ikm.tinkar.provider.executor.ExecutorProvider$Controller

--- a/provider/search-provider/src/main/java/dev/ikm/tinkar/provider/search/Searcher.java
+++ b/provider/search-provider/src/main/java/dev/ikm/tinkar/provider/search/Searcher.java
@@ -318,9 +318,19 @@ public class Searcher {
     public static List<PublicId> getLidrRecordSemanticsFromTestKit(PublicId testKitId){
         List<PublicId> lidrRecordSemanticIds = new ArrayList<>();
 
+        int diagnosticDevicePatternNid;
+        int lidrRecordPatternNid;
+        try {
+            diagnosticDevicePatternNid = DIAGNOSTIC_DEVICE_PATTERN.nid();
+            lidrRecordPatternNid = LIDR_RECORD_PATTERN.nid();
+        } catch (Exception e) {
+            LOG.warn("LIDR patterns not present in this dataset, returning empty LIDR record list: {}", e.getMessage());
+            return lidrRecordSemanticIds;
+        }
+
         EntityHandle.get(testKitId).ifPresent((testKitEntity) -> {
-            EntityService.get().forEachSemanticForComponentOfPattern(testKitEntity.nid(), DIAGNOSTIC_DEVICE_PATTERN.nid(), diagnosticDeviceSemantic -> {
-                EntityService.get().forEachSemanticForComponentOfPattern(diagnosticDeviceSemantic.nid(), LIDR_RECORD_PATTERN.nid(), lidrRecordSemantic -> {
+            EntityService.get().forEachSemanticForComponentOfPattern(testKitEntity.nid(), diagnosticDevicePatternNid, diagnosticDeviceSemantic -> {
+                EntityService.get().forEachSemanticForComponentOfPattern(diagnosticDeviceSemantic.nid(), lidrRecordPatternNid, lidrRecordSemantic -> {
                     lidrRecordSemanticIds.add(lidrRecordSemantic.publicId());
                 });
             });
@@ -408,16 +418,26 @@ public class Searcher {
     public static List<PublicId> getAllowedResultsFromResultConformance(NavigationCalculator navCalc, PublicId resultConformanceId) {
         List<PublicId> allowedResultsList = new ArrayList<>();
 
-        int resultConformanceNid = EntityService.get().nidForPublicId(resultConformanceId);
+        int resultConformanceNid;
+        int quantitativePatternNid;
+        int qualitativePatternNid;
+        try {
+            resultConformanceNid = EntityService.get().nidForPublicId(resultConformanceId);
+            quantitativePatternNid = QUANTITATIVE_ALLOWED_RESULT_SET_PATTERN.nid();
+            qualitativePatternNid = QUALITATIVE_ALLOWED_RESULT_SET_PATTERN.nid();
+        } catch (Exception e) {
+            LOG.warn("LIDR allowed-result patterns not present in this dataset, returning empty list: {}", e.getMessage());
+            return allowedResultsList;
+        }
 
-        EntityService.get().forEachSemanticForComponentOfPattern(resultConformanceNid, QUANTITATIVE_ALLOWED_RESULT_SET_PATTERN.nid(),
+        EntityService.get().forEachSemanticForComponentOfPattern(resultConformanceNid, quantitativePatternNid,
                 (quantitativeResultSet) -> navCalc.stampCalculator().latest(quantitativeResultSet)
                         .ifPresent((latestQuantitativeResultSet) -> {
                             ((IntIdSet) latestQuantitativeResultSet.fieldValues().get(0))
                                     .map(PrimitiveData::publicId)
                                     .forEach(allowedResultsList::add);
                         }));
-        EntityService.get().forEachSemanticForComponentOfPattern(resultConformanceNid, QUALITATIVE_ALLOWED_RESULT_SET_PATTERN.nid(),
+        EntityService.get().forEachSemanticForComponentOfPattern(resultConformanceNid, qualitativePatternNid,
                 (qualitativeResultSet) -> navCalc.stampCalculator().latest(qualitativeResultSet)
                         .ifPresent((latestQualitativeResultSet) -> {
                             ((IntIdSet) latestQualitativeResultSet.fieldValues().get(0))

--- a/provider/search-provider/src/main/resources/META-INF/services/dev.ikm.tinkar.common.service.ServiceLifecycle
+++ b/provider/search-provider/src/main/resources/META-INF/services/dev.ikm.tinkar.common.service.ServiceLifecycle
@@ -1,0 +1,1 @@
+dev.ikm.tinkar.provider.search.SearchProvider$Controller


### PR DESCRIPTION
Part of the `grpc_plugin` workspace feature, spanning 6 repositories. All of them must merge for the feature to be complete.

| Component | Pull request |
|---|---|
| `tinkar-core` ← this PR | https://github.com/ikmdev/tinkar-core/pull/220 |
| `komet-grpc-plugin` | https://github.com/icaglobal/komet-grpc-plugin/pull/1 |
| `komet` | https://github.com/ikmdev/komet/pull/887 |
| `tinkar-service` | https://github.com/icaglobal/tinkar-service/pull/9 |
| `komet-claude-plugin` | https://github.com/knowledge-graphlet/komet-claude-plugin/pull/6 |
| `komet-desktop` | https://github.com/ikmdev/komet-desktop/pull/131 |

Opened by `ws:feature-pr-publish`.
